### PR TITLE
Fix uninitialized report ID

### DIFF
--- a/usbrelay.c
+++ b/usbrelay.c
@@ -77,8 +77,13 @@ int main( int argc, char *argv[]) {
          fprintf(stderr,"unable to open device\n");
          return 1;
       }
-      hid_get_feature_report(handle,buf,sizeof(buf));
-		
+      buf[0] = 0x01;
+      int ret = hid_get_feature_report(handle,buf,sizeof(buf));
+      if (ret == -1) {
+	      perror("hid_get_feature_report");
+	      exit(1);
+      }
+
 		
       if (debug){
          if (buf[7] == 0) printf("%s_1=0\n%s_2=0\n",buf,buf );


### PR DESCRIPTION
When calling hid_get_feature_report(), it is necessary to initialize the
first byte of the buffer to the report ID. The program only works if the
report ID is non-zero. On some systems the non-zero value was there "by
accident", whereas other systems had there zero and the program didn't
work. Setting the report ID to 1 fixes the program for all (two)
systems I currently use.

Also add some error checking.
