### PR TITLE
fix gcc warnings

### DIFF
--- a/usbrelay.c
+++ b/usbrelay.c
@@ -31,39 +31,45 @@ int main( int argc, char *argv[]) {
       relays = malloc(size*(argc+1)); /* Yeah, I know. Not using the first member */
       relays[0].this_serial[0] = '\0';
    } else debug = 1;
-	
+
    /* loop through the command line and grab the relay details */
    for (i = 1 ; i < argc; i++ ) {
       /* copy the arg and bounds check */
       strncpy(arg_t,argv[i],19);
       arg_t[19] =  '\0';
       token = strtok(arg_t, delimiters);
-      if (token != NULL)	
+      if (token != NULL) {
          strcpy(relays[i].this_serial,token);
+      }
       token = strtok((char *)NULL, delimiters);
-      if (token != NULL)
+      if (token != NULL) {
          relays[i].relay_num = atoi(token);
+      }
       token = strtok(NULL, delimiters); 
-      if (token != NULL)
-         if (atoi(token))relays[i].state = ON;
-         else relays[i].state = OFF;
+      if (token != NULL) {
+         if (atoi(token)) {
+             relays[i].state = ON;
+         } else {
+             relays[i].state = OFF;
+         }
+      }
       printf("Orig: %s, Serial: %s, Relay: %d State: %x\n",arg_t,relays[i].this_serial,relays[i].relay_num,relays[i].state);
       relays[i].found = 0; 
    }
 
    product = getenv("USBID");
-   if (product != NULL){
+   if (product != NULL) {
       vendor = strsep(&product, ":");
-      if(vendor && *vendor) {
+      if (vendor && *vendor) {
          vendor_id = strtol(vendor, NULL, 16);
       }
-      if(product && *product) {
+      if (product && *product) {
          product_id = strtol(product, NULL, 16);
       }
    }
    devs = hid_enumerate(vendor_id, product_id);
 
-   cur_dev = devs; 
+   cur_dev = devs;
    while (cur_dev) {
       fprintf(stderr,"Device Found\n  type: %04hx %04hx\n  path: %s\n  serial_number: %ls", cur_dev->vendor_id, cur_dev->product_id, cur_dev->path, cur_dev->serial_number);
       fprintf(stderr,"\n");
@@ -80,33 +86,32 @@ int main( int argc, char *argv[]) {
       buf[0] = 0x01;
       int ret = hid_get_feature_report(handle,buf,sizeof(buf));
       if (ret == -1) {
-	      perror("hid_get_feature_report");
-	      exit(1);
+              perror("hid_get_feature_report");
+              exit(1);
       }
 
-		
-      if (debug){
+
+      if (debug) {
          if (buf[7] == 0) printf("%s_1=0\n%s_2=0\n",buf,buf );
          else if (buf[7] == 1) printf("%s_1=1\n%s_2=0\n",buf,buf);
          else if (buf[7] == 2) printf("%s_1=0\n%s_2=1\n",buf,buf);
-         else if (buf[7] == 3) printf("%s_1=1\n%s_2=1\n",buf,buf);			
+         else if (buf[7] == 3) printf("%s_1=1\n%s_2=1\n",buf,buf);
          /* fprintf(stderr,"Usage: %s %s_1=0  %s\n",argv[0],buf); */
       }
-			
+
       /* loop through the supplied command line and try to match the serial */
-      for (i=1;i<argc;i++){
+      for (i=1;i<argc;i++) {
          printf("Serial: %s, Relay: %d State: %x \n",relays[i].this_serial,relays[i].relay_num,relays[i].state);
-         if ( ! strcmp(relays[i].this_serial,buf)){
+         if (!strcmp(relays[i].this_serial, (const char *) buf)) {
             printf("%d HID Serial: %s ", i, buf);
-            printf("Serial: %s, Relay: %d State: %x\n",relays[i].this_serial,relays[i].relay_num,relays[i].state);	
+            printf("Serial: %s, Relay: %d State: %x\n",relays[i].this_serial,relays[i].relay_num,relays[i].state);
             operate_relay(handle,relays[i].relay_num,relays[i].state);
             relays[i].found = 1;
          }
-
       }
       hid_close(handle);
       printf("\n");
-      cur_dev = cur_dev->next;	
+      cur_dev = cur_dev->next;
    }
    hid_free_enumeration(devs);
 
@@ -114,7 +119,7 @@ int main( int argc, char *argv[]) {
    hid_exit();
 
    for (i=1;i<argc;i++){
-      printf("Serial: %s, Relay: %d State: %x ",relays[i].this_serial,relays[i].relay_num,relays[i].state);	
+      printf("Serial: %s, Relay: %d State: %x ",relays[i].this_serial,relays[i].relay_num,relays[i].state);
       if (relays[i].found )
          printf("--- Found\n");
       else
@@ -123,14 +128,13 @@ int main( int argc, char *argv[]) {
 
    if (relays)
       free(relays);
-   exit(0);			
-
+   exit(0);
 }
 
 int operate_relay(hid_device *handle,unsigned char relay, unsigned char state){
    unsigned char buf[9];// 1 extra byte for the report ID
    int res;
-     
+
    buf[0] = 0x0; //report number
    buf[1] = state;
    buf[2] = relay;


### PR DESCRIPTION
I made whitespace a bit more consistent and fixed the gcc warnings by properly casting the buf argument to strcmp in line 105.
