### PR TITLE
Added a sanity check to operate relay to prevent accidental renaming

### DIFF
--- a/libusbrelay.c
+++ b/libusbrelay.c
@@ -146,7 +146,7 @@ int operate_relay(const char *serial, unsigned char relay, unsigned char target_
    hid_device *handle;
 
    relay_board *board = find_board(serial);
-   if (board != NULL && relay >0 && relay < board->relay_count)
+   if (board != NULL && relay >0 && relay <= board->relay_count)
    {
       handle = hid_open_path(board->path);
 

--- a/libusbrelay.c
+++ b/libusbrelay.c
@@ -146,7 +146,7 @@ int operate_relay(const char *serial, unsigned char relay, unsigned char target_
    hid_device *handle;
 
    relay_board *board = find_board(serial);
-   if (board != NULL)
+   if (board != NULL && relay >0 && relay < board->relay_count)
    {
       handle = hid_open_path(board->path);
 


### PR DESCRIPTION
I accidentally renamed one of my relays to 0x00, which prompted me to add this sanity check.