### PR TITLE
Improve error reporting

### DIFF
--- a/libusbrelay.c
+++ b/libusbrelay.c
@@ -45,6 +45,7 @@ int enumerate_relay_boards(const char *product, int verbose, int debug)
    char *vendor;
    int result = 0;
    struct hid_device_info *devs, *cur_dev;
+   int num_opened = 0, num_error = 0;
 
    //If we were given a product code, use it
    if (product != NULL)
@@ -92,12 +93,14 @@ int enumerate_relay_boards(const char *product, int verbose, int debug)
          handle = hid_open_path(cur_dev->path);
          if (handle)
          {
+	    num_opened++;
             result = get_board_features(&relay_boards[i], handle);
             hid_close(handle);
          }
          else
          {
-            perror("unable to open device - Use root, sudo or set the device permissions via udev\n");
+	    num_error++;
+            perror(cur_dev->path);
             result = -1;
          }
 
@@ -133,6 +136,8 @@ int enumerate_relay_boards(const char *product, int verbose, int debug)
       }
    }
    hid_free_enumeration(devs);
+   if (num_opened == 0 && num_error > 0)
+      fprintf(stderr, "Unable to open any device - Use root, sudo or set the device permissions via udev\n");
    return result;
 }
 


### PR DESCRIPTION
Here, I'm addressing my comment in #36 about conflicting patches.

----

Previously, the error message looked like:

    unable to open device - Use root, sudo or set the device permissions via udev
    : Permission denied

Now, it is:

    /dev/hidraw0: Permission denied

The hint to use root or sudo is printed only when no device can be
opened. The rationale behind this behaviour is the following:

I have a computer with several relays and permissions are set in such
a way that different users can access different relays. It is expected
that a user cannot open all relays and he/she is not supposed to use
sudo. In this case the output will look something like:

    /dev/hidraw3: Permission denied
    /dev/hidraw0: Permission denied
    Device Found
      type: 16c0 05df
      path: /dev/hidraw1
      ...

In case when no relay is accessible, the output will be:

    /dev/hidraw3: Permission denied
    /dev/hidraw0: Permission denied
    /dev/hidraw1: Permission denied
    Unable to open any device - Use root, sudo or set the device permissions via udev