### PR TITLE
enumerate_relay_boards: print correct serial_number in "Device Found"

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ sudo ./usbrelay
 Device Found
   type: 16c0 05df
   path: /dev/hidraw1
-  serial_number: 
+  serial_number: PSUIS
   Manufacturer: www.dcttech.com
   Product:      USBRelay2
   Release:      100
@@ -183,7 +183,7 @@ $ sudo ./usbrelay
 Device Found
   type: 16c0 05df
   path: /dev/hidraw4
-  serial_number: 
+  serial_number: ZXCV
   Manufacturer: www.dcttech.com
   Product:      USBRelay2
   Release:      100
@@ -197,7 +197,7 @@ Orig: ZXCV, Serial: ZXCV, Relay: 0 State: 0
 Device Found
   type: 16c0 05df
   path: /dev/hidraw4
-  serial_number: 
+  serial_number: ZXCV
   Manufacturer: www.dcttech.com
   Product:      USBRelay2
   Release:      100
@@ -211,7 +211,7 @@ $ sudo ./usbrelay
 Device Found
   type: 16c0 05df
   path: /dev/hidraw4
-  serial_number: 
+  serial_number: ZAQ12
   Manufacturer: www.dcttech.com
   Product:      USBRelay2
   Release:      100

--- a/libusbrelay.c
+++ b/libusbrelay.c
@@ -107,7 +107,7 @@ int enumerate_relay_boards(const char *product, int verbose, int debug)
          //Output the device enumeration details if verbose is on
          if (result != -1 && verbose)
          {
-            fprintf(stderr, "Device Found\n  type: %04hx %04hx\n  path: %s\n  serial_number: %ls", cur_dev->vendor_id, cur_dev->product_id, cur_dev->path, cur_dev->serial_number);
+            fprintf(stderr, "Device Found\n  type: %04hx %04hx\n  path: %s\n  serial_number: %s", cur_dev->vendor_id, cur_dev->product_id, cur_dev->path, relay_boards[i].serial);
             fprintf(stderr, "\n");
             fprintf(stderr, "  Manufacturer: %ls\n", cur_dev->manufacturer_string);
             fprintf(stderr, "  Product:      %ls\n", cur_dev->product_string);


### PR DESCRIPTION
I ran into a problem when I was using usbrelay to communicate with my relay module. 
Accidentally, I set an empty serial number to the device. I eventually fixed it, but I got very confused debugging when I realized that usbrelay didn't print the real serial_number name of the device in the "Device Found"-print.

I appears that the serial number is read using **get_board_features** on an open handle opened with **hid_open_path**. However when printed from "struct hid_device_info" from **hid_enumerate** the serial number is empty. 

I introduced a fix for that, so that the serial number is visible. 