### PR TITLE
Prevent crash when enumerating relay boards

### DIFF
--- a/libusbrelay.c
+++ b/libusbrelay.c
@@ -54,9 +54,7 @@ int enumerate_relay_boards(const char *product, int verbose, int debug)
 
 	while (cur_dev != NULL) {
 		// Check if the HID device is a known relay else jump over it
-		if (!known_relay(cur_dev) && cur_dev != NULL) {
-			cur_dev = cur_dev->next;
-		} else {
+		if (known_relay(cur_dev)) {
 			relay_board_count++;
 		}
 		cur_dev = cur_dev->next;


### PR DESCRIPTION
In systems with multiple non-relay-board HID devices, the previous code
stepped past allocated memory causing a SEGV

Signed-off-by: Ben Warren <biggerbadderben@gmail.com>