### PR TITLE
Command line parser improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ usbrelay: usbrelay.c libusbrelay.h libusbrelay.so gitversion.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) gitversion.c $< -lusbrelay -L./ $(LDFLAGS) -o $@
 
 gitversion.c: .git/HEAD .git/index
-	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+	echo "const char *gitversion = \"$(shell git describe --tags --match '[0-9].[0-9]*' --abbrev=10 --dirty)\";" > $@
 
 #We build this once directly for error checking purposes, then let python do the real build
 


### PR DESCRIPTION
I find working with the program quite difficult, because of unusual
command line handling. This is a first step to improve the command
line parser and make it more similar to many GNU/Linux programs. These
commits add long options and --help, but otherwise, the command line
handling stays backward compatible.

In future commits, I plan to extend both the options and the help. My
intention is to add at least an explicit option for changing relay ID.