### PR TITLE
Generate gitversion.h at build time (includes non-git fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 usbrelay
 ._*
 build
+gitversion.h

--- a/gitversion.h
+++ b/gitversion.h
@@ -1,1 +1,0 @@
-#define GITVERSION "Commit: 118"


### PR DESCRIPTION
When building in git repo, ask git for the version, otherwise use
"???" as a fallback.

This should address issue #52.

Later today, I'll extend this PR with another commit for creation of release tar/zip with pregenerated gitversion.h.