### PR TITLE
Dockerfile: build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Base image.
-FROM debian:9
+FROM debian:10
 
 # Install dependencies.
 RUN apt update && apt install -y \
     make \
     gcc \
+    git-core \
     libhidapi-dev \
-    libpython3.5-dev \
+    python3-dev \
     python3


### PR DESCRIPTION
Update Debian to 10 (current stable).

Add `git-core` (lack of it results in empty version string).

Use `python3-dev` instead of `libpython3.5-dev` (fixes "Python.h: No such file or directory")