### PR TITLE
Properly detect multiarch lib directory on Debian systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,12 @@ ifneq ($(wildcard $(PREFIX)/lib64/.),)
     LIBDIR = $(PREFIX)/lib64
 endif
 
-#Catch debian machines with Multiarch (x64)
-ifneq ($(wildcard $(PREFIX)/lib/x86_64-linux-gnu/.),)
-    LIBDIR = $(PREFIX)/lib/x86_64-linux-gnu
-endif
-
-#Catch debian machines with Multiarch (aarch64)
-ifneq ($(wildcard $(PREFIX)/lib/aarch64-linux-gnu/.),)
-    LIBDIR = $(PREFIX)/lib/aarch64-linux-gnu
-endif
-
-#Catch debian machines with Multiarch (arm-linux-gnueabihf)
-ifneq ($(wildcard $(PREFIX)/lib/arm-linux-gnueabihf/.),)
-    LIBDIR = $(PREFIX)/lib/arm-linux-gnueabihf
+#Catch debian machines
+DEB_HOST_MULTIARCH=$(shell dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null)
+ifneq ($(DEB_HOST_MULTIARCH),)
+  ifneq ($(wildcard $(PREFIX)/lib/$(DEB_HOST_MULTIARCH)/.),)
+    LIBDIR = $(PREFIX)/lib/$(DEB_HOST_MULTIARCH)
+  endif
 endif
 
 all: usbrelay libusbrelay.so 


### PR DESCRIPTION
Multiarch in Debian means that multiple architectures can be installed
together in a single system. If multiple architectures are installed,
we should not end up with installing libraries compiled for the host
system the directory for the last detected architecture, which might
be different from the host.

In my case, x86 library was installed to /usr/lib/arm-linux-gnueabihf.

To detect the correct directory, we now use the dpkg-architecture
command, which knows the correct path. I hope this should work on all
Debian/Ubuntu-based systems.

It might be possible that the previously used checks in the Makefile
were also effective on some non-Debian distributions and this stops
working because those distributions don't have the dpkg-architecture
command. The workaround is to specify LIBDIR explicitly on the make
command line:

    make install LIBDIR=/whatever/lib/path