### PR TITLE
Fix heap overflow

### DIFF
--- a/libusbrelay.c
+++ b/libusbrelay.c
@@ -142,7 +142,9 @@ int enumerate_relay_boards(const char *product, int verbose, int debug)
 				}
 				relay++;
 			}
-			cur_dev = cur_dev->next;
+			do {
+				cur_dev = cur_dev->next;
+			} while (cur_dev != NULL && !known_relay(cur_dev));
 		}
 	}
 	hid_free_enumeration(devs);


### PR DESCRIPTION
Memory pointed to by relay_boards variable is allocated only for
"known relays". When iterating the devices, we have to skip "unknown
relays" not to go out of bounds.

This fixes the following error produced by address sanitizer:

    ==93537==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000002468 at pc 0x7f6f3b3a37d1 bp 0x7ffffabaf710 sp 0x7ffffabaf708
    WRITE of size 4 at 0x603000002468 thread T0
        #0 0x7f6f3b3a37d0 in enumerate_relay_boards /home/wsh/src/usbrelay/libusbrelay.c:75
        #1 0x4029ac in main /home/wsh/src/usbrelay/usbrelay.c:175
        #2 0x7f6f3b1fb77f in __libc_start_main (/nix/store/9bh3986bpragfjmr32gay8p95k91q4gy-glibc-2.33-47/lib/libc.so.6+0x2777f)
        #3 0x402239 in _start (/home/wsh/src/usbrelay/usbrelay+0x402239)

    0x603000002468 is located 16 bytes to the right of 24-byte region [0x603000002440,0x603000002458)
    allocated by thread T0 here:
        #0 0x7f6f3b453ff7 in __interceptor_calloc (/nix/store/0kiykyrnrpfhmjwxwx89kxr20hmf5304-gcc-10.3.0-lib/lib/libasan.so.6+0xacff7)
        #1 0x7f6f3b3a379e in enumerate_relay_boards /home/wsh/src/usbrelay/libusbrelay.c:69