### PR TITLE
Fix relay renaming in the help text

### DIFF
--- a/usbrelay.c
+++ b/usbrelay.c
@@ -50,7 +50,7 @@ static char doc[] =
 	"\vWithout ACTION, the actual state of all relays is printed to stdout.\n"
 	"ACTION can be one of:\n"
 	"RELID_N=[0|1] to switch the N-th relay off or on\n"
-	"RELID=NEWID to change relay ID\n"
+	"RELID_0=NEWID to change relay ID\n"
 	;
 
 /* A description of the arguments we accept. */


### PR DESCRIPTION
The change in commit 6d7d664 ("Added a test for second = or _ and
fixed the logic around the previous test", 2021-02-11) prevents the
relays to be renamed with the syntax documented in the --help text.

Previously, it was possible to rename the relay with OLDID=NEWID.
Nowadays, this prints "Invalid relay specification" error. Here, we
correct the help text to use the syntax mentioned in the README, i.e.,
OLDID_0=NEWID.