### PR TITLE
Debian changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS += -O2 -Wall
 HIDAPI = hidraw
-LDFLAGS += -lhidapi-$(HIDAPI)
+LDLIBS += -lhidapi-$(HIDAPI)
 
 PREFIX=/usr
 
@@ -23,10 +23,10 @@ endif
 all: usbrelay libusbrelay.so 
 
 libusbrelay.so: libusbrelay.c libusbrelay.h 
-	$(CC) -shared -fPIC $(CPPFLAGS) $(CFLAGS)  $< $(LDFLAGS) -o $@ 
+	$(CC) -shared -fPIC $(CPPFLAGS) $(CFLAGS)  $< $(LDFLAGS) -o $@ $(LDLIBS)
 
 usbrelay: usbrelay.c libusbrelay.h libusbrelay.so
-	$(CC) $(CPPFLAGS) $(CFLAGS)  $< -lusbrelay -L./ $(LDFLAGS) -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS)  $< -lusbrelay -L./ $(LDFLAGS) -o $@ $(LDLIBS)
 
 # Command to generate version number if running from git repo
 DIR_VERSION = $(shell basename `pwd`)

--- a/io.github.darrylb123.usbrelay.metainfo.xml
+++ b/io.github.darrylb123.usbrelay.metainfo.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.github.darrylb123.usbrelay</id>
+
+  <name>usbrelay</name>
+  <summary>USB-connected electrical relay control, based on hidapi</summary>
+
+  <metadata_license>CC-BY-SA-4.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+
+  <description>
+    <p>
+      A small utility to control USB HID based relays that can be used
+      for home automation or other switching needs. The devices are
+      available from several sources and are able to handle up to 10A
+      250VAC.
+    </p>
+    <p>
+      An example application are USB controllable power switches. You
+      may use such a switch to control the power supply of an external
+      hard disk drive for backup purposes.
+    </p>
+  </description>
+
+  <icon type="stock">utilities-terminal</icon>
+
+  <categories>
+    <category>Utility</category>
+    <category>Electronics</category>
+  </categories>
+
+  <provides>
+    <binary>usbrelay</binary>
+    <modalias>hid:b0003g0001v000016C0p000005DF</modalias>
+    <modalias>hid:b0003g0001v00000519p00002018</modalias>
+  </provides>
+</component>

--- a/usbrelayd.8
+++ b/usbrelayd.8
@@ -1,0 +1,20 @@
+.TH USBRELAYD 8
+.SH NAME
+usbrelayd \- MQTT client for controlling USB HID relay devices
+.SH SYNOPSIS
+.B usbrelayd
+.SH DESCRIPTION
+
+usbrelayd is a daemon that allows controlling locally connected USB
+HID relays remotely via MQTT protocol.
+
+.SH FILES
+.TP
+/etc/usbrelay.conf
+Configuration file.
+
+
+.SH "SEE ALSO"
+.BR usbrelay(1)
+.SH AUTHOR
+This man page was written by Michal Sojka <wsh@2x.cz> for Debian

--- a/usbrelayd.service
+++ b/usbrelayd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=USB Relay MQTT service
+Documentation=man:usbrelayd(8)
 After=network.target
 StartLimitIntervalSec=10
 

--- a/usbrelayd.service
+++ b/usbrelayd.service
@@ -7,7 +7,9 @@ StartLimitIntervalSec=10
 Type=simple
 Restart=always
 RestartSec=1
-User=usbrelay
+DynamicUser=yes
+# SupplementaryGroups should match the group used in udev rules
+SupplementaryGroups=usbrelay
 ExecStart=/usr/bin/python3 /usr/sbin/usbrelayd
 StandardOutput=journal+console
 StandardError=journal+console


### PR DESCRIPTION
Hi, this PR contains a few changes that resulted from packaging the recent version for Debian. Most of them should be harmless. 

But commit fee8cdffe7ae296e490eea4561dfad070b631087 might affect other distributions. With it it is not necessary to create a special user for running usbrelayd. The user is created automatically by systemd only when needed and removed when unneeded. On Debian, which uses `plugdev` group for accessing plugable devices, this means that neither the user nor the group has to be created statically. On distributions without `plugdev` group (Fedora? cc @mefuller), the group still needs to be created but the user needs not. And because [DynamicUser in systemd requires](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=) that either both user and group are statically created or they both do not exist, we run the service under a different (dynamically created) user called `usbrelayd` (with d at the end). This could theoretically break some advanced setups, but I believe it is unlikely.