### PR TITLE
usbrelayd: Add support for paho-mqtt >= 2.0.0

### DIFF
--- a/usbrelayd
+++ b/usbrelayd
@@ -95,7 +95,12 @@ else:
 # connect to the mqtt broker
 
 
-client = mqtt.Client(clientName)
+if "CallbackAPIVersion" in dir(mqtt):
+    # paho-mqtt >= 2.0.0
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, clientName)
+else:
+    # paho-mqtt < 2.0.0
+    client = mqtt.Client(clientName)
 client.connect(mqttBroker) 
 publish_states(client)
 client.on_message=on_message 


### PR DESCRIPTION
See https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html#change-between-version-1-x-and-2-0

Now, usbrelay should work with both paho-mqtt versions 1.x and 2.x.

Closes #111