### PR TITLE
HomeAssistant support

### DIFF
--- a/usbrelayd
+++ b/usbrelayd
@@ -30,6 +30,7 @@ import re
 import sys
 import configparser
 import socket
+import json
 
 def publish_states(client):
     boards = usbrelay_py.board_details()
@@ -47,18 +48,37 @@ def publish_states(client):
             topic = "{0}/{1}/{2}"
             
             if mqtttopic:
-                topic_str = topic.format(mqtttopic + "/stat",board[0],relay)
+                stat_topic_str = topic.format(mqtttopic + "/stat",board[0],relay)
             else:
-                topic_str = topic.format("stat",board[0],relay)
+                stat_topic_str = topic.format("stat",board[0],relay)
 
-            print("State: ", topic_str, relay_state,flush=True)
-            client.publish(topic_str, relay_state, qos=0, retain=True)
+            print("State: ", stat_topic_str, relay_state,flush=True)
+            client.publish(stat_topic_str, relay_state, qos=0, retain=True)
             if mqtttopic:
-                topic_str = topic.format(mqtttopic + "/cmnd",board[0],relay)
+                cmnd_topic_str = topic.format(mqtttopic + "/cmnd",board[0],relay)
             else:
-                topic_str = topic.format("cmnd",board[0],relay)
-            print("Subscribed: ", topic_str,flush=True)
-            client.subscribe(topic_str)
+                cmnd_topic_str = topic.format("cmnd",board[0],relay)
+
+            if homeassistant_topic is not None:
+              config_topic_str = "{0}/switch/{1}/config".format(homeassistant_topic, board[0])
+              payload={"unique_id": board[0],
+                "name": "USB Relay {0}".format(board[0]),
+                "state_topic": stat_topic_str,
+                "command_topic": cmnd_topic_str,
+                # "availability_topic":"home/bedroom/bedroom_socket_switch/available",
+                "payload_on": "ON",
+                "payload_off": "OFF",
+                "state_on": "ON",
+                "state_off": "OFF",
+                "optimistic": False,
+                "qos": 0,
+                "retain": True
+              }
+              payload=json.dumps(payload, indent=2)
+              client.publish(config_topic_str, payload, qos=0, retain=True)
+
+            print("Subscribed: ", cmnd_topic_str,flush=True)
+            client.subscribe(cmnd_topic_str)
             relay += 1
         
 
@@ -111,6 +131,11 @@ mqtttopic  = config['MQTT']['TOPIC']
 
 print("MQTT Broker: ", mqttBroker)
 print("MQTT Client: ", clientName)
+
+homeassistant_topic = config.get('HOMEASSISTANT', 'TOPIC', fallback=None)
+
+if homeassistant_topic is not None:
+    print("HomeAssistant enabled, topic: ", homeassistant_topic)
 
 # Check is the mqtt broker is available
 if hostname_resolves(mqttBroker) == 0:

--- a/usbrelayd.conf
+++ b/usbrelayd.conf
@@ -9,3 +9,9 @@ USER =
 PASS = 
 PORT = 1883
 TOPIC = 
+
+[HOMEASSISTANT]
+# Set this to get usbrelayd to publish the relays with HomeAssistant's
+# discovery protocol.
+# The default value for HA is "homeassistant"
+TOPIC =


### PR DESCRIPTION
This implements support for HA's discovery protocol by exposing each relay as a switch. HA will send the described on and off packets to the specified topics.

With this change the USB relays show up in HomeAssistant and can be controlled with the existing MQTT API.